### PR TITLE
Hotfix/fail to extract with wrong projectid:0x004A of xlsm file.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,4 +4,4 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-oletools = "*"
+oletools = {file = https://github.com/kijeong/oletools/archive/refs/heads/add/projectcompatversion_record.zip}

--- a/Pipfile
+++ b/Pipfile
@@ -4,4 +4,4 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-oletools = {file = https://github.com/kijeong/oletools/archive/refs/heads/add/projectcompatversion_record.zip}
+oletools = {file = "https://github.com/kijeong/oletools/archive/refs/heads/add/projectcompatversion_record.zip"}


### PR DESCRIPTION
[oletools](https://github.com/decalage2/oletools)でExcel 2019以降のxlsmファイルのソースコード抽出しようとするとエラーになる。
原因は、VBAのプロジェクトファイル中のPROJECTCOMPATVERSIONの値が0x004Aに更新され、oletoolsが予期しない値として異常終了してしまうため。
[修正のためのPull Requestはすでに挙がっている](https://github.com/decalage2/oletools/pull/723)が、2年近く放置されておりmergeされる気配がないので、暫定対応として[このfork](https://github.com/kijeong/oletools/tree/add/projectcompatversion_record)をインストールして使用するようにPipfileを修正。